### PR TITLE
Remove hyde from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5102,7 +5102,6 @@
     "husl": "*",
     "huwsettings": "*",
     "hxp": "*",
-    "hyde": "*",
     "hyde-sql": "*",
     "hydna": "*",
     "hydra": "*",


### PR DESCRIPTION
I just removed the package "hyde" from npm because I never
added any code to the module. Removing dependency to prevent
things from breaking.
